### PR TITLE
Refactor ImmutableLogger to be truly immutable and improve tests

### DIFF
--- a/ImmutableLogger.py
+++ b/ImmutableLogger.py
@@ -1,6 +1,6 @@
 import datetime
 import os
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 from dataclasses import dataclass
 import logging
 
@@ -11,9 +11,9 @@ class LogEntry:
     message: str
 
 class ImmutableLogger:
-    def __init__(self, log_file: str = "./app.log", max_file_size: int = 1024 * 1024):
-        """Initialize logger with log file path and max file size (in bytes)."""
-        self._logs: List[LogEntry] = []
+    def __init__(self, log_file: str = "./app.log", max_file_size: int = 1024 * 1024, _logs: Optional[List[LogEntry]] = None):
+        """Initialize logger with log file path, max file size (in bytes), and optional initial logs."""
+        self._logs: Tuple[LogEntry, ...] = tuple(_logs) if _logs else tuple()
         self._log_file = log_file
         self._max_file_size = max_file_size  # Default: 1MB
         self._ensure_directory_exists()
@@ -24,18 +24,22 @@ class ImmutableLogger:
         if directory and not os.path.exists(directory):
             os.makedirs(directory)
 
-    def log(self, level: str, message: str) -> None:
-        """Add a new log entry with the specified level and message, and write to file."""
+    def log(self, level: str, message: str) -> 'ImmutableLogger':
+        """Add a new log entry and return a new logger instance."""
         entry = LogEntry(
             timestamp=datetime.datetime.now(),
             level=level.upper(),
             message=message
         )
-        self._logs.append(entry)
+
         try:
             self._write_to_file(entry)
         except (IOError, OSError) as e:
-            print(f"Failed to write to log file: {e}")
+            logging.error(f"Failed to write to log file: {e}")
+
+        new_logs = list(self._logs)
+        new_logs.append(entry)
+        return ImmutableLogger(self._log_file, self._max_file_size, _logs=new_logs)
 
     def _write_to_file(self, entry: LogEntry) -> None:
         """Write a single log entry to the file and handle log rotation."""
@@ -47,30 +51,30 @@ class ImmutableLogger:
     def _rotate_log_file(self) -> None:
         """Rotate the log file if it exceeds the maximum size."""
         try:
-            timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+            timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
             rotated_file = f"{self._log_file}.{timestamp}"
             if os.path.exists(self._log_file):
                 os.rename(self._log_file, rotated_file)
         except (IOError, OSError) as e:
-            print(f"Failed to rotate log file: {e}")
+            logging.error(f"Failed to rotate log file: {e}")
 
     def get_logs(self, level: str = None) -> Tuple[LogEntry, ...]:
         """Return a tuple of all log entries, optionally filtered by level."""
         if level:
             return tuple(entry for entry in self._logs if entry.level == level.upper())
-        return tuple(self._logs)
+        return self._logs
 
-    def info(self, message: str) -> None:
-        """Log an INFO level message."""
-        self.log("INFO", message)
+    def info(self, message: str) -> 'ImmutableLogger':
+        """Log an INFO level message and return a new logger instance."""
+        return self.log("INFO", message)
 
-    def warning(self, message: str) -> None:
-        """Log a WARNING level message."""
-        self.log("WARNING", message)
+    def warning(self, message: str) -> 'ImmutableLogger':
+        """Log a WARNING level message and return a new logger instance."""
+        return self.log("WARNING", message)
 
-    def error(self, message: str) -> None:
-        """Log an ERROR level message."""
-        self.log("ERROR", message)
+    def error(self, message: str) -> 'ImmutableLogger':
+        """Log an ERROR level message and return a new logger instance."""
+        return self.log("ERROR", message)
 
     def __str__(self) -> str:
         """Return a string representation of all log entries."""

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
-
 <code>
     logger = ImmutableLogger(log_file="./logs/app.log", max_file_size=1024 * 1024)
-    logger.info("Application started")
-    logger.warning("Low disk space")
-    logger.error("Failed to connect to database")
+    logger = logger.info("Application started")
+    logger = logger.warning("Low disk space")
+    logger = logger.error("Failed to connect to database")
     print(logger)  # Prints all logs
     print(logger.get_logs("ERROR"))  # Prints only ERROR logs
 </code>

--- a/test_logging.py
+++ b/test_logging.py
@@ -1,21 +1,102 @@
-# import pytest
-from ImmutableLogger import ImmutableLogger
+import pytest
+import os
+import datetime
+from unittest.mock import mock_open, patch
+from ImmutableLogger import ImmutableLogger, LogEntry
 
+@pytest.fixture
+def logger():
+    """Fixture to provide a logger instance with a temporary log file."""
+    return ImmutableLogger(log_file="test.log")
 
-def test_logger():
-    print("Test started")
-    logger = ImmutableLogger(log_file="my_app.log")
-    print("logger created")
-    #logger.info("Application started")
-    #logger.warning("Low disk space")
-    #logger.error("Failed to connect to database")
-    print(logger)  # Prints all logs
-    # Logs are also written to my_app.log
-    return logger
+def test_log_creation_and_immutability(logger):
+    """Test that a log entry is created and the logger remains immutable."""
+    original_logs = logger.get_logs()
+
+    new_logger = logger.info("Test message")
+
+    # Check that the original logger is unchanged
+    assert len(logger.get_logs()) == 0
+    assert logger.get_logs() is original_logs
+
+    # Check that the new logger has the new log
+    new_logs = new_logger.get_logs()
+    assert len(new_logs) == 1
+    assert new_logs[0].level == "INFO"
+    assert new_logs[0].message == "Test message"
+
+    # Check that the new logger is a different instance
+    assert new_logger is not logger
+
+def test_log_filtering(logger):
+    """Test that log entries can be filtered by level."""
+    logger1 = logger.info("Info message")
+    logger2 = logger1.warning("Warning message")
+    logger3 = logger2.error("Error message")
+
+    info_logs = logger3.get_logs("INFO")
+    assert len(info_logs) == 1
+    assert info_logs[0].level == "INFO"
+
+    warning_logs = logger3.get_logs("WARNING")
+    assert len(warning_logs) == 1
+    assert warning_logs[0].level == "WARNING"
+
+    error_logs = logger3.get_logs("ERROR")
+    assert len(error_logs) == 1
+    assert error_logs[0].level == "ERROR"
+
+    all_logs = logger3.get_logs()
+    assert len(all_logs) == 3
+
+@patch("os.path.exists", return_value=True)
+@patch("os.path.getsize", return_value=2000)
+@patch("os.rename")
+@patch("builtins.open", new_callable=mock_open)
+def test_log_rotation(mock_open_file, mock_rename, mock_getsize, mock_exists, logger):
+    """Test that the log file is rotated when it exceeds the max size."""
+    logger._max_file_size = 1024  # 1KB
+
+    new_logger = logger.info("This should trigger rotation")
+
+    mock_getsize.assert_called_with(logger._log_file)
+    assert mock_rename.call_count == 1
+
+    # Check that the old log file was renamed with a timestamp
+    original_file, rotated_file = mock_rename.call_args[0]
+    assert original_file == logger._log_file
+    assert logger._log_file in rotated_file
+    assert datetime.datetime.now().strftime("%Y-%m-%d") in rotated_file
+
+@patch("os.makedirs")
+def test_directory_creation(mock_makedirs):
+    """Test that the log directory is created if it doesn't exist."""
+    log_file = "./logs/app.log"
+    logger = ImmutableLogger(log_file=log_file)
+
+    directory = os.path.dirname(log_file)
+    mock_makedirs.assert_called_once_with(directory)
+
+def test_get_logs_returns_tuple(logger):
+    """Test that get_logs returns a tuple, which is immutable."""
+    new_logger = logger.info("A message")
+    logs = new_logger.get_logs()
+    assert isinstance(logs, tuple)
+
+def test_str_representation(logger):
+    """Test the string representation of the logger."""
+    logger1 = logger.info("First message")
+    logger2 = logger1.warning("Second message")
+
+    log_str = str(logger2)
+    logs = logger2.get_logs()
+
+    expected_str = "\n".join(
+        f"[{entry.timestamp}] {entry.level}: {entry.message}"
+        for entry in logs
+    )
+
+    assert log_str == expected_str
 
 if __name__ == "__main__":
-    my_log = test_logger()
-    my_log.info("Application started")
-    my_log.warning("Low disk space")
-    my_log.error("Failed to connect to database")
-    print(my_log)
+    pytest.main()


### PR DESCRIPTION
This commit refactors the `ImmutableLogger` class to make it truly immutable. The `log` method and its helpers now return a new logger instance instead of mutating the internal state.

The following improvements have been made:
- The logger is now truly immutable, with the `log` method returning a new instance.
- A comprehensive `pytest` test suite has been added to verify the logger's functionality, including its immutability.
- Error handling has been improved by using the standard `logging` module instead of `print`.
- Log rotation now uses a sortable timestamp.
- The `README.md` has been updated to reflect the new API.